### PR TITLE
Fixed an error in the LeNet challenge instructions.

### DIFF
--- a/ML-Coursework_Complete.ipynb
+++ b/ML-Coursework_Complete.ipynb
@@ -1906,7 +1906,7 @@
     "2. `pool_1` is max pooling layer with a 2x2 window with a stride of 2 (use [`tf.layers.max_pooling2d`](https://www.tensorflow.org/api_docs/python/tf/layers/max_pooling2d))\n",
     "3. `conv_2` is 16 filters with a 5x5 kernel size and stride of 1, ReLU activation\n",
     "4. `pool_2` is max pooling layer with a 2x2 window with a stride of 2\n",
-    "5. `conv_3` is 125 filters with a 1x1 kernel size and stride of 1, ReLU activation\n",
+    "5. `conv_3` is 120 filters with a 1x1 kernel size and stride of 1, ReLU activation\n",
     "6. `flat` is the flattened output of conv_3 (use [`tf.layers.flatten`](https://www.tensorflow.org/api_docs/python/tf/layers/flatten))\n",
     "7. `dropout_1` is a dropout layer with a dropout rate of 0.5 and should be connected to `flat` (use [`tf.layers.dropout`](https://www.tensorflow.org/api_docs/python/tf/layers/dropout) and be sure to set the `training` argument)\n",
     "8. `fc_1` is a fully-connected layer connected to `dropout_1` with 84 units and ReLU activation (use [`tf.layers.dense`](https://www.tensorflow.org/api_docs/python/tf/layers/dense))\n",

--- a/ML-Coursework_Student.ipynb
+++ b/ML-Coursework_Student.ipynb
@@ -1192,7 +1192,7 @@
     "2. `pool_1` is max pooling layer with a 2x2 window with a stride of 2 (use [`tf.layers.max_pooling2d`](https://www.tensorflow.org/api_docs/python/tf/layers/max_pooling2d))\n",
     "3. `conv_2` is 16 filters with a 5x5 kernel size and stride of 1, ReLU activation\n",
     "4. `pool_2` is max pooling layer with a 2x2 window with a stride of 2\n",
-    "5. `conv_3` is 125 filters with a 1x1 kernel size and stride of 1, ReLU activation\n",
+    "5. `conv_3` is 120 filters with a 1x1 kernel size and stride of 1, ReLU activation\n",
     "6. `flat` is the flattened output of conv_3 (use [`tf.layers.flatten`](https://www.tensorflow.org/api_docs/python/tf/layers/flatten))\n",
     "7. `dropout_1` is a dropout layer with a dropout rate of 0.5 and should be connected to `flat` (use [`tf.layers.dropout`](https://www.tensorflow.org/api_docs/python/tf/layers/dropout) and be sure to set the `training` argument)\n",
     "8. `fc_1` is a fully-connected layer connected to `dropout_1` with 84 units and ReLU activation (use [`tf.layers.dense`](https://www.tensorflow.org/api_docs/python/tf/layers/dense))\n",


### PR DESCRIPTION
Step 7 in the instructions for the LeNet challenge suggests that
the third convolution operation (conv_3) should contain 125 filters
while the comment in the code block indicates it should have 120
filters. Adding 125 filters will work, producing comparable
results/model performance. However, the subsequent visualisation
of the activation or feature maps for layer3 will fail when the
subplot index exceeds 120.

This change simply corrects the challenge instructions to be
consistent with the code comments and subsequent visualisation
to avoid confusion.